### PR TITLE
Decreases prerequisites to allow run with maven 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
   </scm>
 
   <prerequisites>
-    <maven>${maven.version}</maven>
+    <maven>3.0.0</maven>
   </prerequisites>
 
   <properties>


### PR DESCRIPTION
I want to use this plugin in a CI that runs on Maven 3.2.x but this plugin has a higher prerequisite. Because of that, I try to decrease the prerequisite to version 3.2.x and I could run the plugin without any problem.
This PR changes the prerequisite to 3.0.0 because I also test the plugin using a maven 3.0.x.