### PR TITLE
WIP JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,23 @@
     <maven.version>3.5.2</maven.version>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.1</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -70,18 +87,6 @@
       <artifactId>junit-vintage-engine</artifactId>
       <version>5.7.0</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.1</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,18 @@
       <artifactId>junit</artifactId>
       <version>4.13.1</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>5.7.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.rudikershaw.gitbuildhook</groupId>
@@ -49,6 +49,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.7.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.13.1</version>
@@ -85,7 +92,6 @@
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
-      <version>5.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/com/rudikershaw/gitbuildhook/AbstractMojoTest.java
+++ b/src/test/java/com/rudikershaw/gitbuildhook/AbstractMojoTest.java
@@ -46,10 +46,11 @@ public class AbstractMojoTest {
      *
      * @param testName the name of the test directory in which the files are kept.
      * @param fileName the name of the file to move into the temporary directory.
+     * @param folder a temporary folder to use.
      * @throws IOException if moving the file in question fails.
      */
-    protected void moveToTempTestDirectory(final String testName, final String fileName) throws IOException {
-        moveToTempTestDirectory(testName, fileName, fileName);
+    protected void moveToTempTestDirectory(final String testName, final String fileName, final TemporaryFolder folder) throws IOException {
+        moveToTempTestDirectory(testName, fileName, fileName, folder);
     }
 
     /**
@@ -57,9 +58,10 @@ public class AbstractMojoTest {
      *
      * @param testName the name of the test directory in which the files are kept.
      * @param fileName the name of the file to move into the temporary directory.
+     * @param folder a temporary folder to use.
      * @throws IOException if moving the file in question fails.
      */
-    protected void moveToTempTestDirectory(final String testName, final String fileName, final String newFileName) throws IOException {
+    protected void moveToTempTestDirectory(final String testName, final String fileName, final String newFileName, final TemporaryFolder folder) throws IOException {
         Files.copy(Paths.get("target/test-classes/" + testName + "/" + fileName),
                    Paths.get(folder.getRoot().getAbsolutePath() + "/" + newFileName),
                    StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
@@ -79,4 +81,5 @@ public class AbstractMojoTest {
         verifier.setLocalRepo(testRepsotiroyDirectory.getAbsolutePath());
         return verifier;
     }
+
 }

--- a/src/test/java/com/rudikershaw/gitbuildhook/AbstractMojoTest.java
+++ b/src/test/java/com/rudikershaw/gitbuildhook/AbstractMojoTest.java
@@ -1,6 +1,6 @@
 package com.rudikershaw.gitbuildhook;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -77,7 +77,7 @@ public class AbstractMojoTest {
     protected Verifier getVerifier(final String project) throws VerificationException {
         final Verifier verifier = new Verifier(project);
         final File testRepsotiroyDirectory = new File("target/test-repo");
-        assertTrue("Plugin must be installed into a local repo for tests", testRepsotiroyDirectory.exists());
+        assertTrue(testRepsotiroyDirectory.exists(), "Plugin must be installed into a local repo for tests");
         verifier.setLocalRepo(testRepsotiroyDirectory.getAbsolutePath());
         return verifier;
     }

--- a/src/test/java/com/rudikershaw/gitbuildhook/AbstractMojoTest.java
+++ b/src/test/java/com/rudikershaw/gitbuildhook/AbstractMojoTest.java
@@ -10,9 +10,9 @@ import java.nio.file.StandardCopyOption;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.plugin.testing.MojoRule;
+import org.apache.maven.it.Verifier;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
-import org.apache.maven.it.Verifier;
 
 /** Abstract test for Mojos. */
 public class AbstractMojoTest {

--- a/src/test/java/com/rudikershaw/gitbuildhook/GitConfigMojoTest.java
+++ b/src/test/java/com/rudikershaw/gitbuildhook/GitConfigMojoTest.java
@@ -9,6 +9,7 @@ import org.apache.maven.it.Verifier;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /** Unit and integration tests for the GitBuildHookMojo. */
 public class GitConfigMojoTest extends AbstractMojoTest {
@@ -20,8 +21,9 @@ public class GitConfigMojoTest extends AbstractMojoTest {
      */
     @Test
     public void testConfigureGitHooksDirectory() throws Exception {
-        moveToTempTestDirectory("test-project-configure", "pom.xml");
-        final File rootFolder = getFolder().getRoot();
+        final TemporaryFolder folder = getFolder();
+        moveToTempTestDirectory("test-project-configure", "pom.xml", folder);
+        final File rootFolder = folder.getRoot();
         assertTrue(rootFolder.exists());
 
         final Verifier verifier = getVerifier(rootFolder.toString());
@@ -38,5 +40,5 @@ public class GitConfigMojoTest extends AbstractMojoTest {
             assertEquals("custom", git.getRepository().getConfig().getString("custom", "config", "name"));
         }
     }
-}
 
+}

--- a/src/test/java/com/rudikershaw/gitbuildhook/GitConfigMojoTest.java
+++ b/src/test/java/com/rudikershaw/gitbuildhook/GitConfigMojoTest.java
@@ -1,7 +1,7 @@
 package com.rudikershaw.gitbuildhook;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 

--- a/src/test/java/com/rudikershaw/gitbuildhook/InitializeMojoTest.java
+++ b/src/test/java/com/rudikershaw/gitbuildhook/InitializeMojoTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 
 import org.apache.maven.it.Verifier;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /** Unit and integration tests for the GitBuildHookMojo. */
 public class InitializeMojoTest extends AbstractMojoTest {
@@ -18,9 +19,10 @@ public class InitializeMojoTest extends AbstractMojoTest {
      */
     @Test
     public void testInitialiseNewGitRepo() throws Exception {
-        moveToTempTestDirectory("test-project-initialise", "pom.xml");
+        final TemporaryFolder folder = getFolder();
+        moveToTempTestDirectory("test-project-initialise", "pom.xml", folder);
 
-        final File rootFolder = getFolder().getRoot();
+        final File rootFolder = folder.getRoot();
         assertTrue(rootFolder.exists());
         final Verifier verifier = getVerifier(rootFolder.toString());
         verifier.executeGoal("install");
@@ -28,5 +30,5 @@ public class InitializeMojoTest extends AbstractMojoTest {
         verifier.assertFilePresent(".git");
         verifier.resetStreams();
     }
-}
 
+}

--- a/src/test/java/com/rudikershaw/gitbuildhook/InitializeMojoTest.java
+++ b/src/test/java/com/rudikershaw/gitbuildhook/InitializeMojoTest.java
@@ -1,6 +1,6 @@
 package com.rudikershaw.gitbuildhook;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/com/rudikershaw/gitbuildhook/InstallMojoTest.java
+++ b/src/test/java/com/rudikershaw/gitbuildhook/InstallMojoTest.java
@@ -1,7 +1,9 @@
 package com.rudikershaw.gitbuildhook;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.IOException;
@@ -9,7 +11,10 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.apache.maven.plugin.MojoFailureException;
+import org.hamcrest.core.Is;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.rules.TemporaryFolder;
 
 /** Unit and integration tests for the GitBuildHookMojo. */
@@ -36,7 +41,7 @@ public class InstallMojoTest extends AbstractMojoTest {
      *
      * @throws IOException if a temp project cannot be created for testing.
      */
-    @Test(expected = MojoFailureException.class)
+    @Test
     public void testFailureFromLackingGitRepo() throws Exception {
         final TemporaryFolder folder = getFolder();
         moveToTempTestDirectory("default-test-project", "pom.xml", folder);
@@ -45,7 +50,10 @@ public class InstallMojoTest extends AbstractMojoTest {
         assertTrue(rootFolder.exists());
         final InstallMojo installMojo = (InstallMojo) getRule().lookupConfiguredMojo(rootFolder, "install");
         assertNotNull(installMojo);
-        installMojo.execute();
+
+        final Executable testMethod = () -> installMojo.execute();
+        final MojoFailureException thrown = assertThrows(MojoFailureException.class, testMethod);
+        assertThat(thrown.getMessage(), Is.is(IsEqual.equalTo("Could not find or initialise a local git repository. A repository is required.")));
     }
 
     /**

--- a/src/test/java/com/rudikershaw/gitbuildhook/InstallMojoTest.java
+++ b/src/test/java/com/rudikershaw/gitbuildhook/InstallMojoTest.java
@@ -1,7 +1,7 @@
 package com.rudikershaw.gitbuildhook;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/com/rudikershaw/gitbuildhook/InstallMojoTest.java
+++ b/src/test/java/com/rudikershaw/gitbuildhook/InstallMojoTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.apache.maven.it.Verifier;
 import org.apache.maven.plugin.MojoFailureException;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /** Unit and integration tests for the GitBuildHookMojo. */
 public class InstallMojoTest extends AbstractMojoTest {
@@ -37,9 +38,10 @@ public class InstallMojoTest extends AbstractMojoTest {
      */
     @Test(expected = MojoFailureException.class)
     public void testFailureFromLackingGitRepo() throws Exception {
-        moveToTempTestDirectory("default-test-project", "pom.xml");
+        final TemporaryFolder folder = getFolder();
+        moveToTempTestDirectory("default-test-project", "pom.xml", folder);
 
-        final File rootFolder = getFolder().getRoot();
+        final File rootFolder = folder.getRoot();
         assertTrue(rootFolder.exists());
         final InstallMojo installMojo = (InstallMojo) getRule().lookupConfiguredMojo(rootFolder, "install");
         assertNotNull(installMojo);
@@ -53,10 +55,11 @@ public class InstallMojoTest extends AbstractMojoTest {
      */
     @Test
     public void testInstallTwoHooks() throws Exception {
-        moveToTempTestDirectory("test-project-install-hooks", "pom.xml");
-        moveToTempTestDirectory("test-project-install-hooks", "hook-to-install.sh");
+        final TemporaryFolder folder = getFolder();
+        moveToTempTestDirectory("test-project-install-hooks", "pom.xml", folder);
+        moveToTempTestDirectory("test-project-install-hooks", "hook-to-install.sh", folder);
 
-        final File rootFolder = getFolder().getRoot();
+        final File rootFolder = folder.getRoot();
         assertTrue(rootFolder.exists());
         final Verifier verifier = getVerifier(rootFolder.toString());
         verifier.executeGoal("install");
@@ -80,11 +83,12 @@ public class InstallMojoTest extends AbstractMojoTest {
      */
     @Test
     public void testUpdateHooks() throws Exception {
-        moveToTempTestDirectory("test-project-reinstall-hooks", "pom.xml");
-        moveToTempTestDirectory("test-project-reinstall-hooks", "hook-to-install.sh");
-        moveToTempTestDirectory("test-project-reinstall-hooks", "hook-to-reinstall.sh");
+        final TemporaryFolder folder = getFolder();
+        moveToTempTestDirectory("test-project-reinstall-hooks", "pom.xml", folder);
+        moveToTempTestDirectory("test-project-reinstall-hooks", "hook-to-install.sh", folder);
+        moveToTempTestDirectory("test-project-reinstall-hooks", "hook-to-reinstall.sh", folder);
 
-        final File rootFolder = getFolder().getRoot();
+        final File rootFolder = folder.getRoot();
         Verifier verifier = getVerifier(rootFolder.toString());
         verifier.executeGoal("install");
         verifier.verifyErrorFreeLog();
@@ -96,7 +100,7 @@ public class InstallMojoTest extends AbstractMojoTest {
         List<String> origionalCommitMsgLines = verifier.loadFile(new File(rootFolder, ".git/hooks/commit-msg"), false);
         assertTrue(origionalCommitMsgLines.contains("origional hook"));
 
-        moveToTempTestDirectory("test-project-reinstall-hooks", "pom2.xml", "pom.xml");
+        moveToTempTestDirectory("test-project-reinstall-hooks", "pom2.xml", "pom.xml", folder);
         verifier = getVerifier(rootFolder.toString());
         verifier.executeGoal("install");
         verifier.verifyErrorFreeLog();
@@ -116,9 +120,10 @@ public class InstallMojoTest extends AbstractMojoTest {
      */
     @Test(expected = MojoFailureException.class)
     public void testFailureFromInvalidHookNames() throws Exception {
-        moveToTempTestDirectory("test-project-invalid-hook", "pom.xml");
+        final TemporaryFolder folder = getFolder();
+        moveToTempTestDirectory("test-project-invalid-hook", "pom.xml", folder);
 
-        final File rootFolder = getFolder().getRoot();
+        final File rootFolder = folder.getRoot();
         assertTrue(rootFolder.exists());
         final InstallMojo installMojo = (InstallMojo) getRule().lookupConfiguredMojo(rootFolder, "install");
         assertNotNull(installMojo);

--- a/src/test/java/com/rudikershaw/gitbuildhook/InstallMojoTest.java
+++ b/src/test/java/com/rudikershaw/gitbuildhook/InstallMojoTest.java
@@ -126,7 +126,7 @@ public class InstallMojoTest extends AbstractMojoTest {
      *
      * @throws IOException if a temp project cannot be created for testing.
      */
-    @Test(expected = MojoFailureException.class)
+    @Test
     public void testFailureFromInvalidHookNames() throws Exception {
         final TemporaryFolder folder = getFolder();
         moveToTempTestDirectory("test-project-invalid-hook", "pom.xml", folder);
@@ -135,7 +135,10 @@ public class InstallMojoTest extends AbstractMojoTest {
         assertTrue(rootFolder.exists());
         final InstallMojo installMojo = (InstallMojo) getRule().lookupConfiguredMojo(rootFolder, "install");
         assertNotNull(installMojo);
-        installMojo.execute();
+
+        final Executable testMethod = () -> installMojo.execute();
+        final MojoFailureException thrown = assertThrows(MojoFailureException.class, testMethod);
+        assertThat(thrown.getMessage(), Is.is(IsEqual.equalTo("Could not find or initialise a local git repository. A repository is required.")));
     }
 
 }


### PR DESCRIPTION
Spotted it was using JUnit v4 so upgrade to JUnit v5, with backwards compatibility via junit-vintage-engine and support to upgrade and add newer tests that support junit-jupiter-engine.

Also upgrade `@Test(expected = Exception.class)` to use `assertThrows` so random unexpected exceptions of the same class don't pass a test that should fail. Checks exception message to ensure it was the expected message.