### PR TITLE
Add classpath support for git hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,6 @@ A common use-case might be to install local git hooks by setting the `core.hooks
           <custom.configuration>true</custom.configuration> 
         </gitConfig>
       </configuration>
-      <dependencies>
-        <dependency>
-          <groupId>my.company</groupId>
-          <artifactId>company-git-hooks</artifactId>
-          <version>[1.2.3,)</version>
-        <dependency>
-      </dependencies>
       <executions>
         <execution>
           <goals>       
@@ -59,13 +52,20 @@ When you run your project build the plugin will configure git to run hooks out o
 
 ```$xml
 ...
-  <configuration>
-    <installHooks>
-      <!-- The location of a git hook to install into the default hooks directory. -->
-      <pre-commit>file_path/to/your/hook.sh</pre-commit>
-      <commit-msg>class_path/package/hook.sh</commit-msg>
-    </installHooks>
-  </configuration>
+      <configuration>
+        <installHooks>
+          <!-- The location of a git hook to install into the default hooks directory. -->
+          <pre-commit>file_path/to/your/hook.sh</pre-commit>
+          <commit-msg>class_path/package/hook.sh</commit-msg>
+        </installHooks>
+      </configuration>
+      <dependencies>
+        <dependency>
+          <groupId>my.company</groupId>
+          <artifactId>company-git-hooks</artifactId>
+          <version>[1.2.3,)</version>
+        <dependency>
+      </dependencies>
 ...
       <goals>       
         <!-- Install specific hooks directly to the default hooks directory. -->

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ A common use-case might be to install local git hooks by setting the `core.hooks
           <custom.configuration>true</custom.configuration> 
         </gitConfig>
       </configuration>
+      <dependencies>
+        <dependency>
+          <groupId>my.company</groupId>
+          <artifactId>company-git-hooks</artifactId>
+          <version>[1.2.3,)</version>
+        <dependency>
+      </dependencies>
       <executions>
         <execution>
           <goals>       
@@ -55,8 +62,8 @@ When you run your project build the plugin will configure git to run hooks out o
   <configuration>
     <installHooks>
       <!-- The location of a git hook to install into the default hooks directory. -->
-      <pre-commit>path/to/your/hook.sh</pre-commit>
-      <commit-msg>path/to/your/hook.sh</commit-msg>
+      <pre-commit>file_path/to/your/hook.sh</pre-commit>
+      <commit-msg>class_path/package/hook.sh</commit-msg>
     </installHooks>
   </configuration>
 ...

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,11 @@
       <version>1.7.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.8.0</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -143,6 +148,19 @@
               <goal>jar</goal>
             </goals>
           </execution>
+          <execution>
+            <id>package-cphooks-for-testing</id>
+            <phase>process-test-resources</phase>
+            <configuration>
+              <classifier>CPHOOKS</classifier>
+              <includes>
+                <include>com/rudikershaw/gitbuildhook/tests/cphooks/**</include>
+              </includes>
+            </configuration>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -154,6 +172,20 @@
             <id>install-for-testing</id>
             <configuration>
               <file>${project.basedir}/target/${project.artifactId}-${project.version}-TEST.jar</file>
+              <localRepositoryPath>${project.basedir}/target/test-repo</localRepositoryPath>
+            </configuration>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>install-cphooks-for-testing</id>
+            <configuration>
+              <groupId>com.rudikershaw.gitbuildhook</groupId>
+              <artifactId>testing-cp-hooks</artifactId>
+              <version>1.2.3</version>
+              <file>${project.basedir}/target/${project.artifactId}-${project.version}-CPHOOKS.jar</file>
               <localRepositoryPath>${project.basedir}/target/test-repo</localRepositoryPath>
             </configuration>
             <phase>process-test-classes</phase>

--- a/src/test/java/com/rudikershaw/gitbuildhook/InstallMojoTest.java
+++ b/src/test/java/com/rudikershaw/gitbuildhook/InstallMojoTest.java
@@ -89,16 +89,24 @@ public class InstallMojoTest extends AbstractMojoTest {
         verifier.executeGoal("install");
         verifier.verifyErrorFreeLog();
         verifier.assertFilePresent(".git/hooks/pre-commit");
+        verifier.assertFilePresent(".git/hooks/commit-msg");
+
         List<String> lines = verifier.loadFile(new File(rootFolder, ".git/hooks/pre-commit"), false);
         assertTrue(lines.contains("install"));
+        List<String> origionalCommitMsgLines = verifier.loadFile(new File(rootFolder, ".git/hooks/commit-msg"), false);
+        assertTrue(origionalCommitMsgLines.contains("origional hook"));
 
         moveToTempTestDirectory("test-project-reinstall-hooks", "pom2.xml", "pom.xml");
         verifier = getVerifier(rootFolder.toString());
         verifier.executeGoal("install");
         verifier.verifyErrorFreeLog();
         verifier.assertFilePresent(".git/hooks/pre-commit");
+        verifier.assertFilePresent(".git/hooks/commit-msg");
+
         lines = verifier.loadFile(new File(rootFolder, ".git/hooks/pre-commit"), false);
         assertTrue(lines.contains("reinstall"));
+        List<String> updatedCommitMsgLines = verifier.loadFile(new File(rootFolder, ".git/hooks/commit-msg"), false);
+        assertTrue(updatedCommitMsgLines.contains("updated hook"));
     }
 
     /**
@@ -116,5 +124,5 @@ public class InstallMojoTest extends AbstractMojoTest {
         assertNotNull(installMojo);
         installMojo.execute();
     }
-}
 
+}

--- a/src/test/resources/com/rudikershaw/gitbuildhook/tests/cphooks/hook-to-install-from-cp.sh
+++ b/src/test/resources/com/rudikershaw/gitbuildhook/tests/cphooks/hook-to-install-from-cp.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "A git thing happened installed from classpath 2"

--- a/src/test/resources/com/rudikershaw/gitbuildhook/tests/cphooks/reinstall-hook-origional.sh
+++ b/src/test/resources/com/rudikershaw/gitbuildhook/tests/cphooks/reinstall-hook-origional.sh
@@ -1,0 +1,1 @@
+origional hook

--- a/src/test/resources/com/rudikershaw/gitbuildhook/tests/cphooks/reinstall-hook-updated.sh
+++ b/src/test/resources/com/rudikershaw/gitbuildhook/tests/cphooks/reinstall-hook-updated.sh
@@ -1,0 +1,1 @@
+updated hook

--- a/src/test/resources/test-project-install-hooks/pom.xml
+++ b/src/test/resources/test-project-install-hooks/pom.xml
@@ -24,12 +24,19 @@
             <pre-rebase>hook-to-install.sh</pre-rebase>
             <pre-applypatch>hook-to-install.sh</pre-applypatch>
             <applypatch-msg>hook-to-install.sh</applypatch-msg>
-            <commit-msg>hook-to-install.sh</commit-msg>
-            <prepare-commit-msg>hook-to-install.sh</prepare-commit-msg>
-            <update>hook-to-install.sh</update>
-            <post-update>hook-to-install.sh</post-update>
+            <commit-msg>com/rudikershaw/gitbuildhook/tests/cphooks/hook-to-install-from-cp.sh</commit-msg>
+            <prepare-commit-msg>com/rudikershaw/gitbuildhook/tests/cphooks/hook-to-install-from-cp.sh</prepare-commit-msg>
+            <update>com/rudikershaw/gitbuildhook/tests/cphooks/hook-to-install-from-cp.sh</update>
+            <post-update>com/rudikershaw/gitbuildhook/tests/cphooks/hook-to-install-from-cp.sh</post-update>
           </installHooks>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>com.rudikershaw.gitbuildhook</groupId>
+            <artifactId>testing-cp-hooks</artifactId>
+            <version>1.2.3</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <goals>

--- a/src/test/resources/test-project-reinstall-hooks/pom.xml
+++ b/src/test/resources/test-project-reinstall-hooks/pom.xml
@@ -19,8 +19,16 @@
         <configuration>
           <installHooks>
             <pre-commit>hook-to-install.sh</pre-commit>
+            <commit-msg>com/rudikershaw/gitbuildhook/tests/cphooks/reinstall-hook-origional.sh</commit-msg>
           </installHooks>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>com.rudikershaw.gitbuildhook</groupId>
+            <artifactId>testing-cp-hooks</artifactId>
+            <version>1.2.3</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <goals>

--- a/src/test/resources/test-project-reinstall-hooks/pom2.xml
+++ b/src/test/resources/test-project-reinstall-hooks/pom2.xml
@@ -19,8 +19,16 @@
         <configuration>
           <installHooks>
             <pre-commit>hook-to-reinstall.sh</pre-commit>
+            <commit-msg>com/rudikershaw/gitbuildhook/tests/cphooks/reinstall-hook-updated.sh</commit-msg>
           </installHooks>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>com.rudikershaw.gitbuildhook</groupId>
+            <artifactId>testing-cp-hooks</artifactId>
+            <version>1.2.3</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
This PR is to add support to retreive git hooks from a dependency.

So something like this could automatically pick up any new hooks and install them via a new `tld.example:company-git-hooks:1.x.x` release.

```
<plugin>
	<groupId>com.rudikershaw.gitbuildhook</groupId>
	<artifactId>git-build-hook-maven-plugin</artifactId>
	<version>3.1.0-SNAPSHOT</version>
	<configuration>
		<installHooks>
			<pre-commit>company-pre-commit-hook</pre-commit>
		</installHooks>
	</configuration>
	<dependencies>
		<dependency>
			<groupId>tld.example</groupId>
			<artifactId>company-git-hooks</artifactId>
			<version>[1.0.0,1.999.999)</version>
		</dependency>
	</dependencies>
</plugin>
    ```

Outstanding Tasks;
[x] Clean Up Code for copying
[x] Clean Up Code for setting exec bit if form classpath
[x] Unit Testing
[x] Check if commons-io is really need for Resource to File copying