### PR TITLE
Pre-Merge-Commit Hook added (git 2.24)

### DIFF
--- a/src/main/java/com/rudikershaw/gitbuildhook/hook/type/GitHookType.java
+++ b/src/main/java/com/rudikershaw/gitbuildhook/hook/type/GitHookType.java
@@ -8,6 +8,9 @@ public enum GitHookType {
     /** Pre commit hook. */
     PRE_COMMIT("pre-commit"),
 
+    /** Pre merge commit hook. */
+    PRE_MERGE_COMMIT("pre-merge-commit"),
+
     /** Pre push hook. */
     PRE_PUSH("pre-push"),
 

--- a/src/test/resources/test-project-install-hooks/pom.xml
+++ b/src/test/resources/test-project-install-hooks/pom.xml
@@ -19,6 +19,7 @@
         <configuration>
           <installHooks>
             <pre-commit>hook-to-install.sh</pre-commit>
+            <pre-merge-commit>hook-to-install.sh</pre-merge-commit>
             <pre-push>hook-to-install.sh</pre-push>
             <pre-rebase>hook-to-install.sh</pre-rebase>
             <pre-applypatch>hook-to-install.sh</pre-applypatch>


### PR DESCRIPTION
This PR adds support for pre-merge-commit hooks. This feature was introduced in git version 2.24

https://github.com/git/git/blob/6098817fd7f64209664c701df30096dc0f4fb876/Documentation/githooks.txt#L106-L125

