### PR TITLE
maven-clean-plugin v3.1.0 fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>3.2.0-SNAPSHOT</version>
+        <version>3.1.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fixes develop branch as 3.2.0-SNAPSHOT renamed too many variables.