### PR TITLE
JUnit5 TemporaryFolder prep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,12 @@
       <artifactId>commons-io</artifactId>
       <version>2.11.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.9.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/test/java/com/rudikershaw/gitbuildhook/AbstractMojoTest.java
+++ b/src/test/java/com/rudikershaw/gitbuildhook/AbstractMojoTest.java
@@ -48,8 +48,8 @@ public class AbstractMojoTest {
      * @param fileName the name of the file to move into the temporary directory.
      * @throws IOException if moving the file in question fails.
      */
-    protected void moveToTempTestDirectory(final String testName, final String fileName) throws IOException {
-        moveToTempTestDirectory(testName, fileName, fileName);
+    protected void moveToTempTestDirectory(final String testName, final String fileName, final TemporaryFolder folder) throws IOException {
+        moveToTempTestDirectory(testName, fileName, fileName, folder);
     }
 
     /**
@@ -59,7 +59,7 @@ public class AbstractMojoTest {
      * @param fileName the name of the file to move into the temporary directory.
      * @throws IOException if moving the file in question fails.
      */
-    protected void moveToTempTestDirectory(final String testName, final String fileName, final String newFileName) throws IOException {
+    protected void moveToTempTestDirectory(final String testName, final String fileName, final String newFileName, final TemporaryFolder folder) throws IOException {
         Files.copy(Paths.get("target/test-classes/" + testName + "/" + fileName),
                    Paths.get(folder.getRoot().getAbsolutePath() + "/" + newFileName),
                    StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
@@ -79,4 +79,5 @@ public class AbstractMojoTest {
         verifier.setLocalRepo(testRepsotiroyDirectory.getAbsolutePath());
         return verifier;
     }
+
 }

--- a/src/test/java/com/rudikershaw/gitbuildhook/GitConfigMojoTest.java
+++ b/src/test/java/com/rudikershaw/gitbuildhook/GitConfigMojoTest.java
@@ -9,6 +9,7 @@ import org.apache.maven.it.Verifier;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /** Unit and integration tests for the GitBuildHookMojo. */
 public class GitConfigMojoTest extends AbstractMojoTest {
@@ -20,8 +21,9 @@ public class GitConfigMojoTest extends AbstractMojoTest {
      */
     @Test
     public void testConfigureGitHooksDirectory() throws Exception {
-        moveToTempTestDirectory("test-project-configure", "pom.xml");
-        final File rootFolder = getFolder().getRoot();
+        final TemporaryFolder folder = getFolder();
+        moveToTempTestDirectory("test-project-configure", "pom.xml", folder);
+        final File rootFolder = folder.getRoot();
         assertTrue(rootFolder.exists());
 
         final Verifier verifier = getVerifier(rootFolder.toString());
@@ -38,5 +40,5 @@ public class GitConfigMojoTest extends AbstractMojoTest {
             assertEquals("custom", git.getRepository().getConfig().getString("custom", "config", "name"));
         }
     }
-}
 
+}

--- a/src/test/java/com/rudikershaw/gitbuildhook/InitializeMojoTest.java
+++ b/src/test/java/com/rudikershaw/gitbuildhook/InitializeMojoTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.jgit.api.Git;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /** Unit and integration tests for the GitBuildHookMojo. */
 public class InitializeMojoTest extends AbstractMojoTest {
@@ -19,9 +20,10 @@ public class InitializeMojoTest extends AbstractMojoTest {
      */
     @Test
     public void testInitialiseNewGitRepo() throws Exception {
-        moveToTempTestDirectory("test-project-initialise", "pom.xml");
+        final TemporaryFolder folder = getFolder();
+        moveToTempTestDirectory("test-project-initialise", "pom.xml", folder);
 
-        final File rootFolder = getFolder().getRoot();
+        final File rootFolder = folder.getRoot();
         assertTrue(rootFolder.exists());
 
         verifyRepositoryInitializedWithoutErrors(rootFolder);
@@ -34,9 +36,10 @@ public class InitializeMojoTest extends AbstractMojoTest {
      */
     @Test
     public void testInitialiseOnExistingRepo() throws Exception {
-        moveToTempTestDirectory("test-project-initialise", "pom.xml");
+        final TemporaryFolder folder = getFolder();
+        moveToTempTestDirectory("test-project-initialise", "pom.xml", folder);
 
-        final File rootFolder = getFolder().getRoot();
+        final File rootFolder = folder.getRoot();
         assertTrue(rootFolder.exists());
         Git.init().setDirectory(rootFolder).call();
 
@@ -50,5 +53,5 @@ public class InitializeMojoTest extends AbstractMojoTest {
         verifier.assertFilePresent(".git");
         verifier.resetStreams();
     }
-}
 
+}

--- a/src/test/java/com/rudikershaw/gitbuildhook/InstallMojoTest.java
+++ b/src/test/java/com/rudikershaw/gitbuildhook/InstallMojoTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.apache.maven.it.Verifier;
 import org.apache.maven.plugin.MojoFailureException;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /** Unit and integration tests for the GitBuildHookMojo. */
 public class InstallMojoTest extends AbstractMojoTest {
@@ -37,9 +38,10 @@ public class InstallMojoTest extends AbstractMojoTest {
      */
     @Test(expected = MojoFailureException.class)
     public void testFailureFromLackingGitRepo() throws Exception {
-        moveToTempTestDirectory("default-test-project", "pom.xml");
+        final TemporaryFolder folder = getFolder();
+        moveToTempTestDirectory("default-test-project", "pom.xml", folder);
 
-        final File rootFolder = getFolder().getRoot();
+        final File rootFolder = folder.getRoot();
         assertTrue(rootFolder.exists());
         final InstallMojo installMojo = (InstallMojo) getRule().lookupConfiguredMojo(rootFolder, "install");
         assertNotNull(installMojo);
@@ -53,10 +55,11 @@ public class InstallMojoTest extends AbstractMojoTest {
      */
     @Test
     public void testInstallTwoHooks() throws Exception {
-        moveToTempTestDirectory("test-project-install-hooks", "pom.xml");
-        moveToTempTestDirectory("test-project-install-hooks", "hook-to-install.sh");
+        final TemporaryFolder folder = getFolder();
+        moveToTempTestDirectory("test-project-install-hooks", "pom.xml", folder);
+        moveToTempTestDirectory("test-project-install-hooks", "hook-to-install.sh", folder);
 
-        final File rootFolder = getFolder().getRoot();
+        final File rootFolder = folder.getRoot();
         assertTrue(rootFolder.exists());
         final Verifier verifier = getVerifier(rootFolder.toString());
         verifier.executeGoal("install");
@@ -80,11 +83,12 @@ public class InstallMojoTest extends AbstractMojoTest {
      */
     @Test
     public void testUpdateHooks() throws Exception {
-        moveToTempTestDirectory("test-project-reinstall-hooks", "pom.xml");
-        moveToTempTestDirectory("test-project-reinstall-hooks", "hook-to-install.sh");
-        moveToTempTestDirectory("test-project-reinstall-hooks", "hook-to-reinstall.sh");
+        final TemporaryFolder folder = getFolder();
+        moveToTempTestDirectory("test-project-reinstall-hooks", "pom.xml", folder);
+        moveToTempTestDirectory("test-project-reinstall-hooks", "hook-to-install.sh", folder);
+        moveToTempTestDirectory("test-project-reinstall-hooks", "hook-to-reinstall.sh", folder);
 
-        final File rootFolder = getFolder().getRoot();
+        final File rootFolder = folder.getRoot();
         Verifier verifier = getVerifier(rootFolder.toString());
         verifier.executeGoal("install");
         verifier.verifyErrorFreeLog();
@@ -96,7 +100,7 @@ public class InstallMojoTest extends AbstractMojoTest {
         List<String> origionalCommitMsgLines = verifier.loadFile(new File(rootFolder, ".git/hooks/commit-msg"), false);
         assertTrue(origionalCommitMsgLines.contains("origional hook"));
 
-        moveToTempTestDirectory("test-project-reinstall-hooks", "pom2.xml", "pom.xml");
+        moveToTempTestDirectory("test-project-reinstall-hooks", "pom2.xml", "pom.xml", folder);
         verifier = getVerifier(rootFolder.toString());
         verifier.executeGoal("install");
         verifier.verifyErrorFreeLog();
@@ -116,9 +120,10 @@ public class InstallMojoTest extends AbstractMojoTest {
      */
     @Test(expected = MojoFailureException.class)
     public void testFailureFromInvalidHookNames() throws Exception {
-        moveToTempTestDirectory("test-project-invalid-hook", "pom.xml");
+        final TemporaryFolder folder = getFolder();
+        moveToTempTestDirectory("test-project-invalid-hook", "pom.xml", folder);
 
-        final File rootFolder = getFolder().getRoot();
+        final File rootFolder = folder.getRoot();
         assertTrue(rootFolder.exists());
         final InstallMojo installMojo = (InstallMojo) getRule().lookupConfiguredMojo(rootFolder, "install");
         assertNotNull(installMojo);


### PR DESCRIPTION
JUnit v5 doesn't support @Rules, this refactors the usage for @TemporaryFolder, so @TempDir can be used once @Test upgraded to junit v5.