### PR TITLE
Remove 'readonly' from gitConfig and installHooks parameters 

### DIFF
--- a/src/main/java/com/rudikershaw/gitbuildhook/GitConfigMojo.java
+++ b/src/main/java/com/rudikershaw/gitbuildhook/GitConfigMojo.java
@@ -23,7 +23,7 @@ public class GitConfigMojo extends GitRepositoryValidator {
     private MavenProject project;
 
     /** The git config to set and the values to set them to. */
-    @Parameter(readonly = true)
+    @Parameter
     private Map<String, String> gitConfig;
 
     @Override

--- a/src/main/java/com/rudikershaw/gitbuildhook/InstallMojo.java
+++ b/src/main/java/com/rudikershaw/gitbuildhook/InstallMojo.java
@@ -27,7 +27,7 @@ import com.rudikershaw.gitbuildhook.validation.GitRepositoryValidator;
 public class InstallMojo extends GitRepositoryValidator {
 
     /** The location of git hooks to install into the default hooks directory. */
-    @Parameter(readonly = true)
+    @Parameter
     private final Map<String, String> installHooks = new HashMap<>();
 
     /** Injected MavenProject containing project related information such as base directory. */


### PR DESCRIPTION
The `gitConfig` and `installHooks` parameters are set as `readonly` but are used to configure the plugin. 
This generates a warning in maven `[WARNING] Parameter 'gitConfig' is read-only, must not be used in configuration`.

Maven version: 3.9.0